### PR TITLE
Filtering by channel causes a PHP error

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 * Author: [Mark Croxton](http://hallmark-design.co.uk/)
 
-## Version 2.0.1
+## Version 2.0.2
 
 * Requires: ExpressionEngine 2
 

--- a/third_party/search_fields/pi.search_fields.php
+++ b/third_party/search_fields/pi.search_fields.php
@@ -2,7 +2,7 @@
 
 $plugin_info = array(
   'pi_name' => 'Search Fields',
-  'pi_version' =>'2.0.1',
+  'pi_version' =>'2.0.2',
   'pi_author' =>'Mark Croxton',
   'pi_author_url' => 'http://www.hallmark-design.co.uk/',
   'pi_description' => 'Search channel entry titles, custom fields, category names, category descriptions and category custom fields.',
@@ -16,7 +16,7 @@ $plugin_info = array(
  * channel entries and categories for keywords/phrase.
  * Outputs a delimited list of entry ids to a placeholder
  *
- * @version 2.0.0
+ * @version 2.0.2
  *
  */
 class Search_fields {
@@ -266,7 +266,7 @@ class Search_fields {
 		// limit to a channel?
 		if ($channel !== '*')
         {
-            if(substr('|', $channel))
+            if(strpos($channel, '|') !== FALSE)
             {
                 $channels = explode('|', $channel);
                 $sql_conditions = "(".$sql_conditions.") AND (";


### PR DESCRIPTION
Searching using channel="" caused a php error when only one channel was being searched, due to using substr() instead of strpos() or strstr(). I can't see how this ever would have worked.

The exact error was (when using the parameter channel="channelname"):

```
A PHP Error was encountered
Severity: Warning
Message: substr() expects parameter 2 to be long, string given
Filename: search_fields/pi.search_fields.php
Line Number: 269
```

Fixed in my pull request.
Cheers
