### PR TITLE
Making it so when no search occurs, 'no results' is not *always* thrown.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ Default is pipe |.
 Single variable placeholder to replace with search results output. 
 Default is search_results (use as {search_results}).
 
+### required= (optional)	
+
+'y' or 'n'.  Sets whether or not a search is required.  If required and no search parameters are present, no_results will be set to true.  If not required and no search parameters are present, the placeholder variable will be set to a blank string so that additional channel entries loop parameters will be processed.
+Default is 'y'.
+
 ### site= (optional)	
 
 The site id.

--- a/third_party/search_fields/pi.search_fields.php
+++ b/third_party/search_fields/pi.search_fields.php
@@ -256,7 +256,7 @@ class Search_fields {
 		if ($sql_conditions == '')
 		{
 			// no valid fields to search	
-			$this->return_data = $this->EE->TMPL->no_results();
+			$this->return_data = $this->EE->TMPL->parse_variables_row($tagdata, array($ph => ''));
 			return; // end the process here
 		}
 		
@@ -335,7 +335,7 @@ class Search_fields {
 				$found_ids .= ($found_ids=='' ? '' : $delimiter).$row['entry_id'];
 			}
 
-			$tagdata = $this->EE->TMPL->swap_var_single($ph, $found_ids, $tagdata);
+			$tagdata = $this->EE->TMPL->parse_variables_row($tagdata, array($ph => $found_ids));
 		
 			// return data
 			$this->return_data = $tagdata;

--- a/third_party/search_fields/pi.search_fields.php
+++ b/third_party/search_fields/pi.search_fields.php
@@ -46,6 +46,7 @@ class Search_fields {
 		$delimiter 	= $this->EE->TMPL->fetch_param('delimiter', '|');
 		$operator 	= strtoupper($this->EE->TMPL->fetch_param('operator')) == 'OR' ? 'OR' : 'AND';
 		$ph 		= $this->EE->TMPL->fetch_param('placeholder', 'search_results');
+		$required = $this->EE->TMPL->fetch_param('required', 'yes') == 'yes' ? 'yes' : 'no';
 		$site 		= $this->EE->TMPL->fetch_param('site', $this->EE->config->item('site_id'));
 		$this->min_length = $this->EE->TMPL->fetch_param('min_length', $this->min_length);
 		
@@ -255,8 +256,15 @@ class Search_fields {
 		// check that we actually have some conditions to match
 		if ($sql_conditions == '')
 		{
-			// no valid fields to search	
-			$this->return_data = $this->EE->TMPL->parse_variables_row($tagdata, array($ph => ''));
+			// no valid fields to search
+			if($required == 'yes')
+			{
+				$this->return_data = $this->EE->TMPL->no_results();
+			}
+			else
+			{
+				$this->return_data = $this->EE->TMPL->parse_variables_row($tagdata, array($ph => ''));
+			}
 			return; // end the process here
 		}
 		


### PR DESCRIPTION
When no search is occurring, the plugin should optionally throw a 'no results' response because always doing so causes conflict with other channel:entries parameters.

For instance, say we have the following code:
`{exp:search_fields search:title="{document_route_keywords}" required="n" no_results="y" search:document_content="{document_route_keywords}" search:document_document_excerpt="{document_route_keywords}" operator="OR" channel="document" parse="inward"}
        {exp:channel:entries entry_id="{search_results}" channel="document" status="open" dynamic="no" paginate="bottom" limit="5" category="{document_route_category_ids}"}`
`

This is code for a documents section that is filterable by keyword and multiple document category groups.

If there are no keywords present ( {document_route_keywords} ), `no_results` will be returned.  However, I may still want to view documents of a certain category.

I added a 'required' parameter to specify whether or not performing a search is required.  If required and no search parameters are present, no_results will be set to true.  If not required and no search parameters are present, the placeholder variable will be set to a blank string so that additional channel entries loop parameters will be processed.
